### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ modman clone https://github.com/tegansnyder/meff.git
 ```
 
 ##### Example:
-[Comparision >](https://github.com/SchumacherFM/Magento-OpCache/blob/master/modman)
+[Comparison >](https://github.com/SchumacherFM/Magento-OpCache/blob/master/modman)
 ```bash
 ➜ php meff.php SchumacherFM_OpCachePanel /var/www/site
 FILES IDENTIFIED FOR: SchumacherFM_OpCachePanel


### PR DESCRIPTION
@tegansnyder, I've corrected a typographical error in the documentation of the [meff](https://github.com/tegansnyder/meff) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
